### PR TITLE
Work with pip 23.1 and above, fixes #2

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -3,7 +3,9 @@
 # RW Penney, July 2010
 
 from setuptools import setup
-import os, re, shutil
+import os, sys, re, shutil
+base_path = os.path.dirname(__file__)
+sys.path.insert(0, base_path)
 from pmcyg.version import PMCYG_VERSION
 
 


### PR DESCRIPTION
As discussed [here](https://github.com/pypa/pip/issues/12030#issuecomment-1587916378), `setup.py` should not assume it can import any local files. It must do all the heavy lifting by itself.